### PR TITLE
Update to EveEveRefTypes model to combat error

### DIFF
--- a/app/models/EveEveRefTypes.php
+++ b/app/models/EveEveRefTypes.php
@@ -7,5 +7,5 @@ class EveEveRefTypes extends Eloquent {
 
 	protected $table = 'eve_reftypes';
 	protected $fillable = array('refTypeID', 'refTypeName');
-	protected $primaryKey = ('refTypeID');
+	protected $primaryKey = 'refTypeID';
 }


### PR DESCRIPTION
Fix to combat the error:

production.ERROR: exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'syntax error, unexpected '('' in /var/www/seat/app/models/EveEveRefTypes.php:10
