### PR TITLE
Standings restricted to 2 decimal places

### DIFF
--- a/app/views/character/view/contacts.blade.php
+++ b/app/views/character/view/contacts.blade.php
@@ -31,11 +31,11 @@
                       </td>
                       <td>
                         @if ($contact->standing == 0)
-                        {{ $contact->standing }}
+                          {{ \App\Services\Helpers\Helpers::format_number($contact->standing,2) }}
                         @elseif ($contact->standing > 0)
-                        <span class="text-green">{{ $contact->standing }}</span>
+                          <span class="text-green">{{ \App\Services\Helpers\Helpers::format_number($contact->standing,2) }}</span>
                         @else
-                        <span class="text-red">{{ $contact->standing }}</span>
+                          <span class="text-red">{{ \App\Services\Helpers\Helpers::format_number($contact->standing,2) }}</span>
                         @endif
                       </td>
                     </tr>

--- a/app/views/corporation/memberstandings/memberstandings.blade.php
+++ b/app/views/corporation/memberstandings/memberstandings.blade.php
@@ -27,7 +27,7 @@
                     <img src="{{ App\Services\Helpers\Helpers::generateEveImage( $standing->fromID, 32) }}" class='img-circle' style='width: 18px;height: 18px;'>
                     {{ $standing->fromName }}
                   </td>
-                  <td>{{ $standing->standing }}</td>
+                  <td>{{ App\Services\Helpers\Helpers::format_number($standing->standing,2) }}</td>
                 </tr>
 
               @endforeach
@@ -53,7 +53,7 @@
                     <img src="{{ App\Services\Helpers\Helpers::generateEveImage( $standing->fromID, 32) }}" class='img-circle' style='width: 18px;height: 18px;'>
                     {{ $standing->fromName }}
                   </td>
-                  <td>{{ $standing->standing }}</td>
+                  <td>{{ App\Services\Helpers\Helpers::format_number($standing->standing,2) }}</td>
                 </tr>
 
               @endforeach
@@ -79,7 +79,7 @@
                     <img src="{{ App\Services\Helpers\Helpers::generateEveImage( $standing->fromID, 32) }}" class='img-circle' style='width: 18px;height: 18px;'>
                     {{ $standing->fromName }}
                   </td>
-                  <td>{{ $standing->standing }}</td>
+                  <td>{{ App\Services\Helpers\Helpers::format_number($standing->standing,2) }}</td>
                 </tr>
 
               @endforeach


### PR DESCRIPTION
The EVE client only displays standings to 2 decimal places, so to keep in line with that.

Also add some indentation that was missing from a blade
