### PR TITLE
Starbase display improvements

### DIFF
--- a/app/views/corporation/starbase/starbase.blade.php
+++ b/app/views/corporation/starbase/starbase.blade.php
@@ -365,7 +365,7 @@
                                              @if(!is_null($module_content['module_name']))
                                               <span class="text-muted">(called {{ $module_content['module_name'] }})</span>
                                              @endif
-                                            at {{ $module_content['mapName'] }}
+                                            <!--at {{ $module_content['mapName'] }} -->
                                             @if($module_content['capacity'] > 0)
                                               is currently <b>{{ round(($module_content['used_volume'] / $module_content['capacity']) * 100, 0) }}%</b> full
                                               with {{ count($module_content['contents']) }} item(s).
@@ -416,14 +416,16 @@
 
                                         @endif  {{-- contents count --}}
 
-                                        <hr> <!-- devide modules -->
+                                        @if(!next($modules) === false)
+                                            <hr> <!-- divide modules -->
+                                        @endif
 
                                       @endforeach {{-- group modules --}}
 
                                     </div>
                                   </div>
                                 </div>  <!-- ./panel -->
-                                <hr>
+                                <br>
 
                               </div> <!-- ./panel-group -->
 
@@ -465,7 +467,7 @@
                                              @if(!is_null($module_content['module_name']))
                                               <span class="text-muted">(called {{ $module_content['module_name'] }})</span>
                                              @endif
-                                            at {{ $module_content['mapName'] }}
+                                            <!-- at {{ $module_content['mapName'] }} -->
                                             @if($module_content['capacity'] > 0)
                                               is currently <b>{{ round(($module_content['used_volume'] / $module_content['capacity']) * 100, 0) }}%</b> full
                                               with {{ count($module_content['contents']) }} item(s).
@@ -516,14 +518,16 @@
 
                                         @endif  {{-- contents count --}}
 
-                                        <hr> <!-- devide modules -->
+                                        @if(!next($modules) === false)
+                                            <hr> <!-- divide modules -->
+                                        @endif
 
                                       @endforeach {{-- group modules --}}
 
                                     </div>
                                   </div>
                                 </div>  <!-- ./panel -->
-                                <hr>
+                                <br>
 
                               </div> <!-- ./panel-group -->
 

--- a/app/views/corporation/starbase/starbase.blade.php
+++ b/app/views/corporation/starbase/starbase.blade.php
@@ -91,9 +91,9 @@
 
         <div class="col-md-4">
           <div class="nav-tabs-custom">
-		  <div class="tab-content">
-		    <h4><b>{{ $details->itemName }}</b></h4>
-		  </div>
+          <div class="tab-content">
+            <h4><b>{{ $details->itemName }}</b></h4>
+          </div>
             <ul class="nav nav-tabs">
               <li class="active"><a href="#tab_1{{ $details->itemID }}" data-toggle="tab" id="{{ $details->itemID }}">Tower Info</a></li>
               <li><a href="#tab_2{{ $details->itemID }}" data-toggle="tab">Tower Configuration</a></li>
@@ -101,7 +101,6 @@
             </ul>
             <div class="tab-content">
               <div class="tab-pane active" id="tab_1{{ $details->itemID }}">
-                
                 @if ($details->state == 4)
                   <span class="label label-success pull-right">{{ $tower_states[$details->state] }}</span>
                 @else
@@ -314,9 +313,9 @@
 
                                         @endif  {{-- contents count --}}
 
-										@if(!next($modules) === false)
-											<hr> <!-- divide modules -->
-										@endif
+                                        @if(!next($modules) === false)
+                                            <hr> <!-- divide modules -->
+                                        @endif
 
                                       @endforeach {{-- group modules --}}
 
@@ -324,7 +323,7 @@
                                   </div>
                                 </div>  <!-- ./panel -->
                                 <!-- <hr> -->
-								<br> <!-- Makes the spacing between module groups less thick -->
+                                <br> <!-- Makes the spacing between module groups less thick -->
 
                               </div> <!-- ./panel-group -->
 

--- a/app/views/corporation/starbase/starbase.blade.php
+++ b/app/views/corporation/starbase/starbase.blade.php
@@ -262,7 +262,7 @@
                                              @if(!is_null($module_content['module_name']))
                                               <span class="text-muted">(called {{ $module_content['module_name'] }})</span>
                                              @endif
-                                            at {{ $module_content['mapName'] }}
+                                            <!-- at {{ $module_content['mapName'] }} -->
                                             @if($module_content['capacity'] > 0)
                                               is currently <b>{{ round(($module_content['used_volume'] / $module_content['capacity']) * 100, 0) }}%</b> full
                                               with {{ count($module_content['contents']) }} item(s).

--- a/app/views/corporation/starbase/starbase.blade.php
+++ b/app/views/corporation/starbase/starbase.blade.php
@@ -91,6 +91,7 @@
 
         <div class="col-md-4">
           <div class="nav-tabs-custom">
+		  <h4><b>{{ $details->itemName }}</b></h4>
             <ul class="nav nav-tabs">
               <li class="active"><a href="#tab_1{{ $details->itemID }}" data-toggle="tab" id="{{ $details->itemID }}">Tower Info</a></li>
               <li><a href="#tab_2{{ $details->itemID }}" data-toggle="tab">Tower Configuration</a></li>
@@ -98,7 +99,7 @@
             </ul>
             <div class="tab-content">
               <div class="tab-pane active" id="tab_1{{ $details->itemID }}">
-                <h4><b>{{ $details->itemName }}</b></h4>
+                
                 @if ($details->state == 4)
                   <span class="label label-success pull-right">{{ $tower_states[$details->state] }}</span>
                 @else

--- a/app/views/corporation/starbase/starbase.blade.php
+++ b/app/views/corporation/starbase/starbase.blade.php
@@ -91,7 +91,9 @@
 
         <div class="col-md-4">
           <div class="nav-tabs-custom">
-		  <h4><b>{{ $details->itemName }}</b></h4>
+		  <div class="tab-content">
+		    <h4><b>{{ $details->itemName }}</b></h4>
+		  </div>
             <ul class="nav nav-tabs">
               <li class="active"><a href="#tab_1{{ $details->itemID }}" data-toggle="tab" id="{{ $details->itemID }}">Tower Info</a></li>
               <li><a href="#tab_2{{ $details->itemID }}" data-toggle="tab">Tower Configuration</a></li>
@@ -312,14 +314,17 @@
 
                                         @endif  {{-- contents count --}}
 
-                                        <hr> <!-- devide modules -->
+										@if(!next($modules) === false)
+											<hr> <!-- divide modules -->
+										@endif
 
                                       @endforeach {{-- group modules --}}
 
                                     </div>
                                   </div>
                                 </div>  <!-- ./panel -->
-                                <hr>
+                                <!-- <hr> -->
+								<br> <!-- Makes the spacing between module groups less thick -->
 
                               </div> <!-- ./panel-group -->
 


### PR DESCRIPTION
Moved the starbase location display out of the Tower Info Tab
Removed the ``<hr>`` between module groups (replaced by ``<br>``)
Added logic to prevent ``<hr>`` after last module in module group
Removed location name from individual modules (visible from the top)

Screenshot:
![screenshot 2015-01-02 23 57 29](https://cloud.githubusercontent.com/assets/3704376/5600507/7bb47290-92db-11e4-99f5-5eeddd28bc6d.png)
