### PR TITLE
Enhance Corporation Member Security

### DIFF
--- a/app/controllers/CorporationController.php
+++ b/app/controllers/CorporationController.php
@@ -1320,67 +1320,59 @@ class CorporationController extends BaseController
                 App::abort(404);
 
         $member_roles = DB::table('corporation_msec_roles as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
         $member_roles_base = DB::table('corporation_msec_roles_at_base as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
         $member_roles_hq = DB::table('corporation_msec_roles_at_hq as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
         $member_roles_other = DB::table('corporation_msec_roles_at_other as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
         $member_roles_grantable = DB::table('corporation_msec_grantable_roles as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
         $member_roles_grantable_base = DB::table('corporation_msec_grantable_roles_at_base as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
         $member_roles_grantable_hq = DB::table('corporation_msec_grantable_roles_at_hq as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
         $member_roles_grantable_other = DB::table('corporation_msec_grantable_roles_at_other as cmr')
-            ->select(DB::raw('cmr.characterID, cmr.name, GROUP_CONCAT(rolemap.roleName SEPARATOR \',\') AS roleName'))
-            ->join(DB::raw('eve_corporation_rolemap as rolemap'),'cmr.roleID','=','rolemap.roleID')
-            ->where('cmr.corporationID', $corporationID)
-            ->groupBy('cmr.characterID')
-            ->orderBy('cmr.name', 'asc')
+            ->select(DB::raw('characterID, name, GROUP_CONCAT(roleID SEPARATOR \',\') AS roleID'))
+            ->where('corporationID', $corporationID)
+            ->groupBy('characterID')
+            ->orderBy('name', 'asc')
             ->get();
 
 
@@ -1408,6 +1400,7 @@ class CorporationController extends BaseController
             ->with('member_roles_grantable_other',  $member_roles_grantable_other)
             ->with('member_roles_log',              $member_roles_log)
             ->with('member_titles_map',             $member_titles_map) // JSON!
+            ->with('corporationID',                 $corporationID)
         ;
     }
 

--- a/app/database/seeds/EveCorporationRolemapSeeder.php
+++ b/app/database/seeds/EveCorporationRolemapSeeder.php
@@ -74,13 +74,13 @@ class EveCorporationRolemapSeeder extends Seeder
             array('roleID' => 16777216,           'roleName' => 'Can query Hangar 5'),
             array('roleID' => 33554432,           'roleName' => 'Can query Hangar 6'),
             array('roleID' => 67108864,           'roleName' => 'Can query Hangar 7'),
-            array('roleID' => 4398046511104,      'roleName' => 'Can take from Container 1'),
-            array('roleID' => 8796093022208,      'roleName' => 'Can take from Container 2'),
-            array('roleID' => 17592186044416,     'roleName' => 'Can take from Container 3'),
-            array('roleID' => 35184372088832,     'roleName' => 'Can take from Container 4'),
-            array('roleID' => 70368744177664,     'roleName' => 'Can take from Container 5'),
-            array('roleID' => 140737488355328,    'roleName' => 'Can take from Container 6'),
-            array('roleID' => 281474976710656,    'roleName' => 'Can take from Container 7'),
+            array('roleID' => 4398046511104,      'roleName' => 'Can take Container from Hangar 1'),
+            array('roleID' => 8796093022208,      'roleName' => 'Can take Container from Hangar 2'),
+            array('roleID' => 17592186044416,     'roleName' => 'Can take Container from Hangar 3'),
+            array('roleID' => 35184372088832,     'roleName' => 'Can take Container from Hangar 4'),
+            array('roleID' => 70368744177664,     'roleName' => 'Can take Container from Hangar 5'),
+            array('roleID' => 140737488355328,    'roleName' => 'Can take Container from Hangar 6'),
+            array('roleID' => 281474976710656,    'roleName' => 'Can take Container from Hangar 7'),
         ));
     }
 }

--- a/app/views/corporation/membersecurity/membersecurity.blade.php
+++ b/app/views/corporation/membersecurity/membersecurity.blade.php
@@ -51,7 +51,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -85,7 +91,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -119,7 +131,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -153,7 +171,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -187,7 +211,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -221,7 +251,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -255,7 +291,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -289,7 +331,13 @@
                           <img src='{{ App\Services\Helpers\Helpers::generateEveImage($e->characterID, 32) }}' class='img-circle' style='width: 18px;height: 18px;'>
                           {{ $e->name }}
                         </td>
-                        <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList($e->roleName) }}</td>
+                        <td>
+                          <ul>
+                            @foreach( App\Services\Helpers\Helpers::getSecRolesArray($e->roleID, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        </td>
                       </tr>
 
                     @endforeach
@@ -379,39 +427,113 @@
                   <tbody>
                     <tr>
                       <td>Roles</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->roles)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->roles, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->roles, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>
                     </tr>
                     <tr>
                       <td>Roles (HQ)</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->rolesAtHQ)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->rolesAtHQ, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->rolesAtHQ, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>
                     </tr>
                     <tr>
                       <td>Roles (Base)</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->rolesAtBase)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->rolesAtBase, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->rolesAtBase, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>
                     </tr>
                     <tr>
                       <td>Roles (other)</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->rolesAtOther)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->rolesAtOther, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->rolesAtOther, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>
                     </tr>
                     <tr>
                       <td>Grantable Roles</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->grantableRoles)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRoles, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRoles, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>
                     </tr>
                     <tr>
                       <td>Grantable Roles (HQ)</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->grantableRolesAtHQ)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRolesAtHQ, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRolesAtHQ, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>     
                     </tr>
                     <tr>
                       <td>Grantable Roles (Base)</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->grantableRolesAtBase)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRolesAtBase, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRolesAtBase, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>
                     </tr>
                     <tr>
                       <td>Grantable Roles (Other)</td>
-                      <td>{{ App\Services\Helpers\Helpers::makePrettyMemberRoleList(App\Services\Helpers\Helpers::getPrettySecRoles($title->grantableRolesAtOther)) }} </td>
+                      <td>
+                        @if(count(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRolesAtOther, $corporationID)))
+                          <ul>
+                            @foreach(App\Services\Helpers\Helpers::getSecRolesArray($title->grantableRolesAtOther, $corporationID) as $e)
+                              <li>{{ $e }}</li>
+                            @endforeach
+                          </ul>
+                        @endif
+                      </td>
                     </tr>
                   </tbody>
                 </table>
               </div> <!-- ./box-body -->
+              @if(count(App\Services\Helpers\Helpers::getMembersForTitle($corporationID, $title->titleID)))
+                <div class="box-footer">
+                  <p>Assigned Member(s):</p>
+                    <ul>
+                      @foreach(App\Services\Helpers\Helpers::getMembersForTitle($corporationID, $title->titleID) as $e)
+                        <li><a href="{{ action('CharacterController@getView', array('characterID' => $e->characterID)) }}">{{ $e-> name }}</a></li>
+                      @endforeach
+                    </ul>
+                </div>
+              @endif
             </div><!-- ./box -->
           </div>
         @endforeach


### PR DESCRIPTION
* adds mapping to reflect in EVE names of Divisions and Hangars
* corrected "Container take" permission description
* needs a reseed of the Corporation Rolemap (`php artisan db:seed --class=EveCorporationRolemapSeeder`)
* uses a short caching on DB query to not hit DB multiple times with same lookup query

It finally uses some Regex instead of many in_array() lookups, instead of the screenshot in #148 showed.
Here is a screeny: ![image](https://cloud.githubusercontent.com/assets/2454083/5600809/ead670e4-92e3-11e4-9d8c-bf9169970bf1.png)
