### PR TITLE
fix addition of new user with admin checked, issue #320

### DIFF
--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -103,13 +103,15 @@ class UserController extends BaseController
             $user->password = Hash::make(Input::get('password'));
             $user->activated = 1;
 
+            $user->save();
+
+            // After user is saved and has a user_id
+            // we can add it to the admin group if necessary
             if (Input::get('is_admin') == 'yes') {
 
                 $adminGroup = \Auth::findGroupByName('Administrators');
-                $user->addGroup($adminGroup);
+                Auth::addUserToGroup($user, $adminGroup);
             }
-
-            $user->save();
 
             return Redirect::action('UserController@getAll')
                 ->with('success', 'User ' . Input::get('email') . ' has been added');


### PR DESCRIPTION
User creation would fail when 'Superuser' was checked with the following: http://pastebin.com/hMfDrjuG

This would occur in postNewUser() as there is no addGroup method. Changed things to use Auth::addUserToGroup() as is done elsewhere in the code.

The $user->save() had to be moved above this logic in order to avoid a constraint violation (need the user_id to exist before addUserToGroup can do its stuff).