### PR TITLE
fix Mail search

### DIFF
--- a/app/controllers/DashboardController.php
+++ b/app/controllers/DashboardController.php
@@ -157,9 +157,11 @@ class DashboardController extends BaseController
             $character_mail = DB::table('character_mailmessages')
                 ->join('account_apikeyinfo_characters', 'character_mailmessages.characterID', '=', 'account_apikeyinfo_characters.characterID')
                 ->join('character_mailbodies', 'character_mailmessages.messageID', '=', 'character_mailbodies.messageID')
-                ->where('character_mailmessages.senderName', 'like', '%' . Input::get('q') . '%')
-                ->orWhere('character_mailmessages.title', 'like', '%' . Input::get('q') . '%')
-                ->orWhere('character_mailbodies.body', 'like', '%' . Input::get('q') . '%');
+                ->where(function($query) {
+                    $query->where('character_mailmessages.senderName', 'like', '%' . Input::get('q') . '%')
+                        ->orWhere('character_mailmessages.title', 'like', '%' . Input::get('q') . '%')
+                        ->orWhere('character_mailbodies.body', 'like', '%' . Input::get('q') . '%');
+                });
 
             // Ensure we only get result for characters we have access to
             if (!\Auth::hasAccess('recruiter'))

--- a/app/views/search.blade.php
+++ b/app/views/search.blade.php
@@ -159,7 +159,6 @@
                   <thead>
                     <tr>
                       <th>Sender Name</th>
-                      <th>Sender Corporation</th>
                       <th>Title</th>
                       <th>Sent</th>
                       <th>Body</th>
@@ -176,7 +175,6 @@
                             {{ App\Services\Helpers\Helpers::highlightKeyword($message->senderName, $keyword) }}
                           </a>
                         </td>
-                        <td>{{ $message->corporationName }}</td>
                         <td>{{ App\Services\Helpers\Helpers::highlightKeyword($message->title, $keyword) }}</td>
                         <td>{{ $message->sentDate }}</td>
                         <td>


### PR DESCRIPTION
* PR for issue #322 reported by @freedenizen
* the query conditions need that logical grouping or it ignores the `whereIn` call
* the view shows the receiver corporation as that from the sender, which is misleading