### PR TITLE
fixed HIC typeID on skill sheet and added Industrial Command Ships

### DIFF
--- a/app/views/character/view/character_skills.blade.php
+++ b/app/views/character/view/character_skills.blade.php
@@ -500,6 +500,32 @@
                                     <tr>
                                         <td data-order="heavyinterdictioncruiser">Heavy Interdiction Cruisers</td>
                                         <td>
+                                          @if (App\Services\Helpers\Helpers::findSkillLevel($character_skills, 28609) == 5)
+                                            <span class="label label-success">5</span>
+                                          @elseif (App\Services\Helpers\Helpers::findSkillLevel($character_skills, 28609) == 0)
+                                            <span class="label label-default">{{ App\Services\Helpers\Helpers::findSkillLevel($character_skills, 28609) }}</span>
+                                          @elseif (App\Services\Helpers\Helpers::findSkillLevel($character_skills, $s) <= 2)
+                                            <span class="label label-danger">{{ App\Services\Helpers\Helpers::findSkillLevel($character_skills, 28609) }}</span>
+                                          @else
+                                            <span class="label label-primary">{{ App\Services\Helpers\Helpers::findSkillLevel($character_skills, 28609) }}</span>
+                                          @endif
+
+                                          @if (App\Services\Helpers\Helpers::findSkillLevel($character_skills, 28609) > 0)
+                                            {{--*/$skill5 = false;/*--}}
+                                            @foreach( array(3335, 3334, 3332, 3333) as $s)
+                                              @if(App\Services\Helpers\Helpers::findSkillLevel($character_skills, $s) == 5)
+                                                {{--*/$skill5 = true;/*--}}
+                                              @endif
+                                            @endforeach
+                                            @if($skill5 == false)
+                                            <span class="label label-danger">Ship Skill missing!</span>
+                                            @endif
+                                          @endif
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td data-order="industrialcommandships">Industrial Command Ships</td>
+                                        <td>
                                           @if (App\Services\Helpers\Helpers::findSkillLevel($character_skills, 29637) == 5)
                                             <span class="label label-success">5</span>
                                           @elseif (App\Services\Helpers\Helpers::findSkillLevel($character_skills, 29637) == 0)


### PR DESCRIPTION
The typeID for the HIC skill was incorrect in app/views/character/view/character_skills.blade.php and was actually for Industrial Command Ships. As that
didn't exist, I added it and corrected the typeID for the HIC skill.

This time to dev as it should have been.

Accidental merge with master was #327, reverted with #328