### PR TITLE
[BUGFIX] Added migration to set columns last_login and last_login_source...

### DIFF
--- a/app/database/migrations/2015_02_05_221915_SeatUsersNullableColumns.php
+++ b/app/database/migrations/2015_02_05_221915_SeatUsersNullableColumns.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Class SeatUsersNullableColumns
+ *
+ * Sets last_login and last_login_source to be nullable.
+ */
+class SeatUsersNullableColumns extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Possibly @TODO: create conditionals to write raw queries for all supported storage types
+        DB::statement('ALTER TABLE `seat_users` MODIFY `last_login` datetime NULL;');
+        DB::statement('ALTER TABLE `seat_users` MODIFY `last_login_source` varchar(255) COLLATE utf8_unicode_ci NULL;');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Possibly @TODO: create conditionals to write raw queries for all supported storage types
+        DB::statement('ALTER TABLE `seat_users` MODIFY `last_login` datetime NOT NULL;');
+
+        DB::statement('ALTER TABLE `seat_users` MODIFY `last_login_source`'
+            . ' varchar(255) COLLATE utf8_unicode_ci NOT NULL;');
+    }
+
+}


### PR DESCRIPTION
... columns as nullable. Must use raw queries to achieve this, so perhaps create conditionals to cater for other supported storage methods.

Solves this bug: [Failing to install #333](https://github.com/eve-seat/seat/issues/333) and also an unreported bug when creating a user in back end.

**This is the unreported bug that is fixed:**
When adding new user from back end:
URI: /configuration/user/new-user
```bash
Exception message:
SQLSTATE[HY000]: General error: 1364 Field 'last_login' doesn't have a default value (SQL: insert into `seat_users` (`email`, `username`, `password`, `activated`, `updated_at`, `created_at`) values (email@address.com, username, KEY-HASH-HERE, 1, 2015-02-05 21:31:37, 2015-02-05 21:31:37))
```

### Caveats
 * If application is installed with a data storage that does not support the SQL syntax, the migration will fail

### Why this solution anyway
 * IMO the correct value when a user has not logged in is NULL. This is better than putting some fictitious information like
```php
$user->last_login = new \DateTime;
```
 * The same goes for *last_login_source*: The user has never logged in, so why put a value like "127.0.0.1"?
 * If people are using unsupported storage methods, they should get an error when running that migration. This so they can add conditionals to the file to add raw query for their storage type
 * The problems will be manageable - few migration files will probably ever use raw queries.

### Alternative fix
Modify the User model; if last_login and last_login_source is not set, then add the following default values;
 * last_login = 0000-00-00 00:00:00
 * last_login_source = 0.0.0.0