### PR TITLE
Cache app settings

### DIFF
--- a/app/services/settings/SettingHelper.php
+++ b/app/services/settings/SettingHelper.php
@@ -142,12 +142,12 @@ class SettingHelper
 
                         // Looks like we have a user setting, lets do a
                         // db lookup for it.
-	                    $setting_value = Cache::get('key', function() use ($effective_user_id, $setting_name) {
+	                    $setting_value = \Cache::get('key', function() use ($effective_user_id, $setting_name) {
 
 		                    $setting_value = \SeatUserSetting::where('user_id', $effective_user_id)
 		                        ->where('setting', $setting_name)
 			                    ->pluck('value');
-		                    Cache::forever(self::getUserSettingCacheKeyPrefix($effective_user_id).$setting_name, $setting_value);
+		                    \Cache::forever(self::getUserSettingCacheKeyPrefix($effective_user_id).$setting_name, $setting_value);
 
 		                    return $setting_value;
 	                    });
@@ -176,10 +176,10 @@ class SettingHelper
 
             // So we dont have a user setting for whatever reason,
             // so lets check the SeAT global settings.
-	        $setting_value = Cache::get('key', function() use ($setting_name) {
+	        $setting_value = \Cache::get('key', function() use ($setting_name) {
 
 		        $setting_value = \SeatSetting::where('setting', $setting_name)->pluck('value');
-		        Cache::forever('seat.settings.system.'.$setting_name, $setting_value);
+		        \Cache::forever('seat.settings.system.'.$setting_name, $setting_value);
 
 		        return $setting_value;
 	        });
@@ -249,7 +249,7 @@ class SettingHelper
             $user_setting->save();
 
 	        // cache this value forever to save on DB calls
-	        Cache::forever(self::getUserSettingCacheKeyPrefix(\Auth::User()->id).$setting_name, $setting_value);
+	        \Cache::forever(self::getUserSettingCacheKeyPrefix(\Auth::User()->id).$setting_name, $setting_value);
 
             // Return as we are done
             return true;
@@ -266,7 +266,7 @@ class SettingHelper
             $global_setting->save();
 
 	        // cache this value forever to save on DB calls
-	        Cache::forever(self::getSystemSettingCacheKeyPrefix().$setting_name, $setting_value);
+	        \Cache::forever(self::getSystemSettingCacheKeyPrefix().$setting_name, $setting_value);
 
             return true;
         }

--- a/app/services/settings/SettingHelper.php
+++ b/app/services/settings/SettingHelper.php
@@ -142,20 +142,22 @@ class SettingHelper
 
                         // Looks like we have a user setting, lets do a
                         // db lookup for it.
-	                    $cache_key = self::getUserSettingCacheKeyPrefix($effective_user_id, $setting_name);
-	                    $setting_value = \Cache::get($cache_key, function() use ($effective_user_id, $setting_name, $cache_key) {
+                        $cache_key = self::getUserSettingCacheKeyPrefix($effective_user_id, $setting_name);
+                        $setting_value = \Cache::get($cache_key, function() use ($effective_user_id, $setting_name, $cache_key) {
 
-		                    $setting_value = \SeatUserSetting::where('user_id', $effective_user_id)
-		                        ->where('setting', $setting_name)
-			                    ->pluck('value');
-		                    \Cache::forever($cache_key, $setting_value);
+                            $setting_value = \SeatUserSetting::where('user_id', $effective_user_id)
+                                ->where('setting', $setting_name)
+                                ->pluck('value');
 
-		                    return $setting_value;
-	                    });
+	                        // cache result
+                            \Cache::forever($cache_key, $setting_value);
+
+                            return $setting_value;
+                        });
 
                         if($setting_value) {
-	                        // Found the user setting, return that!
-	                        return $setting_value;
+                            // Found the user setting, return that!
+                            return $setting_value;
                         }
 
 
@@ -177,20 +179,22 @@ class SettingHelper
 
             // So we dont have a user setting for whatever reason,
             // so lets check the SeAT global settings.
-	        $cache_key = self::getSystemSettingCacheKeyPrefix($setting_name);
-	        $setting_value = \Cache::get($cache_key, function() use ($setting_name, $cache_key) {
+            $cache_key = self::getSystemSettingCacheKeyPrefix($setting_name);
+            $setting_value = \Cache::get($cache_key, function() use ($setting_name, $cache_key) {
 
-		        $setting_value = \SeatSetting::where('setting', $setting_name)->pluck('value');
-		        \Cache::forever($cache_key, $setting_value);
+                $setting_value = \SeatSetting::where('setting', $setting_name)->pluck('value');
 
-		        return $setting_value;
-	        });
+	            // cache result
+                \Cache::forever($cache_key, $setting_value);
+
+                return $setting_value;
+            });
 
             // If we have a database entry for the setting, return
             // that as the value
             if($setting_value) {
-	            // Found the system setting, return that!
-	            return $setting_value;
+                // Found the system setting, return that!
+                return $setting_value;
             }
 
         } catch (\Exception $e) {}
@@ -250,9 +254,9 @@ class SettingHelper
             $user_setting->value = $setting_value;
             $user_setting->save();
 
-	        // cache this value forever to save on DB calls
-	        $cache_key = self::getUserSettingCacheKeyPrefix(\Auth::User()->id, $setting_name);
-	        \Cache::forever($cache_key, $setting_value);
+            // cache this value forever to save on DB calls
+            $cache_key = self::getUserSettingCacheKeyPrefix(\Auth::User()->id, $setting_name);
+            \Cache::forever($cache_key, $setting_value);
 
             // Return as we are done
             return true;
@@ -268,9 +272,9 @@ class SettingHelper
             $global_setting->value = $setting_value;
             $global_setting->save();
 
-	        // cache this value forever to save on DB calls
-	        $cache_key = self::getSystemSettingCacheKeyPrefix($setting_name);
-	        \Cache::forever($cache_key, $setting_value);
+            // cache this value forever to save on DB calls
+            $cache_key = self::getSystemSettingCacheKeyPrefix($setting_name);
+            \Cache::forever($cache_key, $setting_value);
 
             return true;
         }


### PR DESCRIPTION
This will cache app settings and user settings using the cache driver in laravel. 

On the dashboard, this results in 13 SQL queries executed instead of 30. While these queries are small, they add up to about a 10-15ms reduction in execution time on a contention free box. More heavily loaded system will be even more performant.