### PR TITLE
Fix calls of Cache::set() to Cache::put()

### DIFF
--- a/app/eveapi/BaseAPI.php
+++ b/app/eveapi/BaseAPI.php
@@ -84,7 +84,7 @@ class BaseApi
         // cache
         if (\Cache::get('eve_api_error_count') >= \Config::get('seat.error_limit')) {
 
-            \Cache::set('eve_api_down', true, 30);
+            \Cache::put('eve_api_down', true, 30);
             \Cache::decrement('eve_api_error_count', 10);
         }
 

--- a/app/eveapi/account/AccountAPIKeyInfo.php
+++ b/app/eveapi/account/AccountAPIKeyInfo.php
@@ -80,7 +80,7 @@ class APIKeyInfo extends BaseApi
                     // Get time of IP ban in minutes, rounded up to the next whole minute
                     $time = round(($e->cached_until_unixtime - $e->request_time_unixtime) / 60, 0, PHP_ROUND_HALF_UP);
 
-                    \Cache::set('eve_api_down', true, $time);
+                    \Cache::put('eve_api_down', true, $time);
                     return;
 
                 // "EVE backend database temporarily disabled.""
@@ -88,7 +88,7 @@ class APIKeyInfo extends BaseApi
                     // The EVE API Database is apparently down, so mark the
                     // server as 'down' in the cache so that subsequent
                     // calls don't fail because of this.
-                    \Cache::set('eve_api_down', true, 30);
+                    \Cache::put('eve_api_down', true, 30);
                     return;
 
                 // "Web site database temporarily disabled."
@@ -96,7 +96,7 @@ class APIKeyInfo extends BaseApi
                     // The EVE API Database is apparently down, so mark the
                     // server as 'down' in the cache so that subsequent
                     // calls don't fail because of this.
-                    \Cache::set('eve_api_down', true, 30);
+                    \Cache::put('eve_api_down', true, 30);
                     return;
 
                 // "Authentication failure. Legacy API keys can no longer be


### PR DESCRIPTION
Cache::set() is not a valid method of the cache driver.