### PR TITLE
Correct error on hasAccess() for people groups

### DIFF
--- a/app/controllers/ApiKeyController.php
+++ b/app/controllers/ApiKeyController.php
@@ -658,7 +658,7 @@ class ApiKeyController extends BaseController
 
         // Prepare the people information. 'people_groups_view_all' permissions
         // get to see everything, where users should only see their own stuff
-        if (!\Auth::hasAccess('people_groups_view_all')) {
+        if (\Auth::hasAccess('people_groups_view_all')) {
 
             // SUUPER ADMIN Show all the things
             $people = array();


### PR DESCRIPTION
if not hasAccess('people_groups_view_all') has the effect of hiding all the people groups from admins or users with relevant permissions and instead shows it to people who don't have permissions to view all people groups.